### PR TITLE
Added strikethrough support

### DIFF
--- a/SwiftyMarkdown.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/SwiftyMarkdown.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/SwiftyMarkdown/SwiftyMarkdown.swift
+++ b/SwiftyMarkdown/SwiftyMarkdown.swift
@@ -35,13 +35,16 @@ enum LineStyle : Int {
 	case Bold
 	case Code
 	case Link
+  case Strikethrough
 	
 	static func styleFromString(string : String ) -> LineStyle {
 		if string == "**" || string == "__" {
 			return .Bold
 		} else if string == "*" || string == "_" {
 			return .Italic
-		} else if string == "`" {
+    } else if string == "~~" {
+      return .Strikethrough
+    } else if string == "`" {
 			return .Code
 		} else if string == "["  {
 			return .Link
@@ -92,7 +95,7 @@ public class SwiftyMarkdown {
 
 	
 	let string : String
-	let instructionSet = NSCharacterSet(charactersInString: "[\\*_`")
+	let instructionSet = NSCharacterSet(charactersInString: "[\\*_`~")
 	
 	/**
 	
@@ -398,6 +401,9 @@ public class SwiftyMarkdown {
 			finalFont = UIFont(descriptor: boldDescriptor, size: styleSize)
 		}
 		
+    if style == .Strikethrough {
+      attributes[NSStrikethroughStyleAttributeName] = NSUnderlineStyle.StyleSingle.rawValue
+    }
 		
 		attributes[NSFontAttributeName] = finalFont
 		

--- a/SwiftyMarkdownTests/SwiftyMarkdownTests.swift
+++ b/SwiftyMarkdownTests/SwiftyMarkdownTests.swift
@@ -69,6 +69,8 @@ class SwiftyMarkdownTests: XCTestCase {
 		let codeWithinString = "A string with `code` (should not be indented)"
 		let italicAtStartOfString = "*An italicised string*"
 		let italicWithinString = "A string with *italicised* text"
+    let strikethroughAtStartOfString = "~~A strikethrough string~~"
+    let strikethroughWithinString = "A string with a **strikethrough** word"
 		
 		let multipleBoldWords = "__A bold string__ with a **mix** **of** bold __styles__"
 		let multipleCodeWords = "`A code string` with multiple `code` `instances`"
@@ -95,6 +97,12 @@ class SwiftyMarkdownTests: XCTestCase {
 		md = SwiftyMarkdown(string: italicWithinString)
 		XCTAssertEqual(md.attributedString().string, "A string with italicised text\n")
 		
+    md = SwiftyMarkdown(string: strikethroughAtStartOfString)
+    XCTAssertEqual(md.attributedString().string, "A strikethrough string\n")
+    
+    md = SwiftyMarkdown(string: strikethroughWithinString)
+    XCTAssertEqual(md.attributedString().string, "A string with a strikethrough word\n")
+    
 		md = SwiftyMarkdown(string: multipleBoldWords)
 		XCTAssertEqual(md.attributedString().string, "A bold string with a mix of bold styles\n")
 		


### PR DESCRIPTION
I added support for strikethrough by writing `~~word~~` -> ~~word~~.
