### PR TITLE
Fix last \n and empty lines

### DIFF
--- a/SwiftyMarkdown/SwiftyMarkdown.swift
+++ b/SwiftyMarkdown/SwiftyMarkdown.swift
@@ -144,7 +144,7 @@ open class SwiftyMarkdown {
 				skipLine = false
 				continue
 			}
-			var line = theLine
+			var line = theLine == "" ? " " : theLine
 			for heading in headings {
 				
 				if let range =  line.range(of: heading) , range.lowerBound == line.startIndex {

--- a/SwiftyMarkdown/SwiftyMarkdown.swift
+++ b/SwiftyMarkdown/SwiftyMarkdown.swift
@@ -226,7 +226,9 @@ open class SwiftyMarkdown {
 			}
 			
 			// Append a new line character to the end of the processed line
-			attributedString.append(NSAttributedString(string: "\n"))
+			if lineCount < lines.count {
+				attributedString.append(NSAttributedString(string: "\n"))
+			}
 			currentType = .body
 		}
 		

--- a/SwiftyMarkdown/SwiftyMarkdown.swift
+++ b/SwiftyMarkdown/SwiftyMarkdown.swift
@@ -293,15 +293,17 @@ open class SwiftyMarkdown {
 		while matchedCharacters.contains("\\") {
 			if let hasRange = matchedCharacters.range(of: "\\") {
 				
-				// FIXME: Possible error in range
-				let newRange  = hasRange.lowerBound..<matchedCharacters.index(hasRange.upperBound, offsetBy: 1)
-				foundCharacters = foundCharacters + matchedCharacters.substring(with: newRange)
-				
-				matchedCharacters.removeSubrange(newRange)
+				if matchedCharacters.characters.count > 1 {
+					let newRange = hasRange.lowerBound..<matchedCharacters.index(hasRange.upperBound, offsetBy: 1)
+					foundCharacters = foundCharacters + matchedCharacters.substring(with: newRange)
+					
+					matchedCharacters.removeSubrange(newRange)
+				} else {
+					break
+				}
 			}
 			
 		}
-		
 		
 		return (matchedCharacters, foundCharacters.replacingOccurrences(of: "\\", with: ""))
 	}


### PR DESCRIPTION
First, I have replace empty lines by one space for the NSString.boundingRect parsing. I use SwiftyMarkdown for chat application and I need to have the estimated frame of the TextView. So before this change, the attibutedText generated by an empty line was null. It was that the return of boundingRect was wrong.
Secondly, I have remove the last \n of the string for the same reason as before. 

for a markdown test :

```
# Heading

## Sub-heading

### Another deeper heading
 
 
Paragraphs are separated
by a blank line.



Two spaces at the end of a line leave a  
line break.




Text attributes _italic_, 
*italic*, __bold__, **bold**, 
`monospace`.

Horizontal rule:





---





Bullet list:

* apples
* oranges
* pears








Numbered list:

  1. apples
  2. oranges
  3. pears










A [link](http://example.com).
```

Berfore : 

<img width="469" alt="capture d ecran 2017-01-06 a 10 42 09" src="https://cloud.githubusercontent.com/assets/6064892/21713946/ce7c151e-d3fc-11e6-91b6-15e3a3879270.png">

After :

<img width="473" alt="capture d ecran 2017-01-06 a 10 44 36" src="https://cloud.githubusercontent.com/assets/6064892/21714006/27445558-d3fd-11e6-9b51-fc1dcf9b5698.png">


And for the last \n.

Before :

<img width="466" alt="capture d ecran 2017-01-06 a 10 46 56" src="https://cloud.githubusercontent.com/assets/6064892/21714066/77e93352-d3fd-11e6-8ce0-a494bce3e885.png">

After :

<img width="465" alt="capture d ecran 2017-01-06 a 10 46 19" src="https://cloud.githubusercontent.com/assets/6064892/21714064/696333dc-d3fd-11e6-8ca0-a9b2d6e528f9.png">
