### PR TITLE
Fixes an erroneous identification of `Alt-H2` headers.

### DIFF
--- a/SwiftyMarkdown/SwiftyMarkdown.swift
+++ b/SwiftyMarkdown/SwiftyMarkdown.swift
@@ -212,18 +212,24 @@ enum LineStyle : Int {
 			if lineCount  < lines.count {
 				let nextLine = lines[lineCount]
 				
-				if let range = nextLine.range(of: "=") , range.lowerBound == nextLine.startIndex {
+				let hasNonWhiteSpaceCharacters = (line.rangeOfCharacter(from: CharacterSet.whitespacesAndNewlines.inverted) != nil)
+                
+				if hasNonWhiteSpaceCharacters, let range = nextLine.range(of: "=") , range.lowerBound == nextLine.startIndex {
 					// Make H1
 					currentType = .h1
 					// We need to skip the next line
 					skipLine = true
 				}
 				
-				if let range = nextLine.range(of: "-") , range.lowerBound == nextLine.startIndex {
-					// Make H2
-					currentType = .h2
-					// We need to skip the next line
-					skipLine = true
+				if hasNonWhiteSpaceCharacters, let nextRange = nextLine.range(of: "-") , nextRange.lowerBound == nextLine.startIndex {
+					if let range = line.range(of: "-"), range.lowerBound == line.startIndex {
+						// This is a bullet list, not an `Alt-H2`, don't skip
+					} else {
+						// Make H2
+						currentType = .h2
+						// We need to skip the next line
+						skipLine = true
+					}
 				}
 			}
 			

--- a/SwiftyMarkdownTests/SwiftyMarkdownTests.swift
+++ b/SwiftyMarkdownTests/SwiftyMarkdownTests.swift
@@ -275,6 +275,20 @@ class SwiftyMarkdownTests: XCTestCase {
 //		XCTAssertEqual(md.attributedString().string, "Twitter @VoyageTravelApp\n")
 	}
 	
+    /*
+        The reason for this test is because the list of items dropped every other item in bullet lists marked with "-"
+        The faulty result was: "A cool title\n \n- Här har vi svenska ÅÄÖåäö tecken\n \nA Link\n"
+        As you can see, "- Point number one" and "- Point number two" are mysteriously missing.
+        It incorrectly identified rows as `Alt-H2` 
+     */
+    func testInternationalCharactersInList() {
+        
+        let extected = "A cool title\n \n- Point number one\n- Här har vi svenska ÅÄÖåäö tecken\n- Point number two\n \nA Link\n"
+        let input = "# A cool title\n\n- Point number one\n- Här har vi svenska ÅÄÖåäö tecken\n- Point number two\n\n[A Link](http://dooer.com)"
+        let output = SwiftyMarkdown(string: input).attributedString().string
 
+        XCTAssertEqual(output, extected)
+        
+    }
 	
 }


### PR DESCRIPTION
For unordered lists constructed with "`-`"-chars, it incorrectly identified every odd row as a `Alt-H2` row.

Example in unit test.