### PR TITLE
Fix build break: "Cannot capture lastElement before it is declared"

### DIFF
--- a/Sources/SwiftyMarkdown/SwiftyTokeniser.swift
+++ b/Sources/SwiftyMarkdown/SwiftyTokeniser.swift
@@ -93,7 +93,7 @@ public class SwiftyTokeniser {
 		}
 		
 		var output : [Token] = []
-		
+		var lastElement = elementArray.first!
 		
 		func empty( _ string : inout String, into tokens : inout [Token] )  {
 			guard !string.isEmpty else {
@@ -106,7 +106,6 @@ public class SwiftyTokeniser {
 			tokens.append(token)
 		}
 		
-		var lastElement = elementArray.first!
 		var accumulatedString = ""
 		for element in elementArray {
 			guard element.type != .escape else {


### PR DESCRIPTION
@SimonFairbairn not sure if this is exactly the cause, but my project runs on Swift 5 and fails to build because of the issue in the title. Moving the lastElement declaration fixes the issue.