### PR TITLE
Added LinkStyles to customize underline properties

### DIFF
--- a/Sources/SwiftyMarkdown/SwiftyMarkdown.swift
+++ b/Sources/SwiftyMarkdown/SwiftyMarkdown.swift
@@ -136,7 +136,8 @@ If that is not set, then the system default will be used.
 }
 
 @objc open class LinkStyles : BasicStyles {
-    open var underlineStyle: NSUnderlineStyle = .single
+    public var underlineStyle: NSUnderlineStyle = .single
+    public lazy var underlineColor: UIColor = self.color
 }
 
 /// A class that takes a [Markdown](https://daringfireball.net/projects/markdown/) string or file and returns an NSAttributedString with the applied styles. Supports Dynamic Type.
@@ -557,15 +558,16 @@ extension SwiftyMarkdown {
 				attributes[.foregroundColor] = self.bold.color
 			}
 			
-			if let linkIdx = styles.firstIndex(of: .link), linkIdx < token.metadataStrings.count {
-				attributes[.foregroundColor] = self.link.color
-				attributes[.font] = self.font(for: line, characterOverride: .link)
-				attributes[.link] = token.metadataStrings[linkIdx] as AnyObject
-				
-				if underlineLinks {
+            if let linkIdx = styles.firstIndex(of: .link), linkIdx < token.metadataStrings.count {
+                attributes[.foregroundColor] = self.link.color
+                attributes[.font] = self.font(for: line, characterOverride: .link)
+                attributes[.link] = token.metadataStrings[linkIdx] as AnyObject
+                
+                if underlineLinks {
                     attributes[.underlineStyle] = self.link.underlineStyle.rawValue as AnyObject
-				}
-			}
+                    attributes[.underlineColor] = self.link.underlineColor
+                }
+            }
 						
 			if styles.contains(.strikethrough) {
 				attributes[.font] = self.font(for: line, characterOverride: .strikethrough)

--- a/Sources/SwiftyMarkdown/SwiftyMarkdown.swift
+++ b/Sources/SwiftyMarkdown/SwiftyMarkdown.swift
@@ -135,7 +135,9 @@ If that is not set, then the system default will be used.
 	public var alignment: NSTextAlignment = .left
 }
 
-
+@objc open class LinkStyles : BasicStyles {
+    open var underlineStyle: NSUnderlineStyle = .single
+}
 
 /// A class that takes a [Markdown](https://daringfireball.net/projects/markdown/) string or file and returns an NSAttributedString with the applied styles. Supports Dynamic Type.
 @objc open class SwiftyMarkdown: NSObject {
@@ -222,7 +224,7 @@ If that is not set, then the system default will be used.
 	open var blockquotes = LineStyles()
 	
 	/// The styles to apply to any links found in the Markdown
-	open var link = BasicStyles()
+	open var link = LinkStyles()
 	
 	/// The styles to apply to any bold text found in the Markdown
 	open var bold = BasicStyles()
@@ -561,7 +563,7 @@ extension SwiftyMarkdown {
 				attributes[.link] = token.metadataStrings[linkIdx] as AnyObject
 				
 				if underlineLinks {
-					attributes[.underlineStyle] = NSUnderlineStyle.single.rawValue as AnyObject
+                    attributes[.underlineStyle] = self.link.underlineStyle.rawValue as AnyObject
 				}
 			}
 						


### PR DESCRIPTION
Hi! I'm adding this new style to allow customizations like this:
```swift
md.link.underlineStyle = NSUnderlineStyle.single.union(.patternDot)
md.link.underlineColor = .purple
```