### PR TITLE
allow mutating line and character rules

### DIFF
--- a/Sources/SwiftyMarkdown/CharacterRule.swift
+++ b/Sources/SwiftyMarkdown/CharacterRule.swift
@@ -45,7 +45,7 @@ public struct CharacterRule : CustomStringConvertible {
 	public let primaryTag : CharacterRuleTag
 	public let tags : [CharacterRuleTag]
 	public let escapeCharacters : [Character]
-	public let styles : [Int : CharacterStyling]
+	public var styles : [Int : CharacterStyling]
 	public let minTags : Int
 	public let maxTags : Int
 	public var metadataLookup : Bool = false

--- a/Sources/SwiftyMarkdown/SwiftyLineProcessor.swift
+++ b/Sources/SwiftyMarkdown/SwiftyLineProcessor.swift
@@ -54,11 +54,11 @@ public struct FrontMatterRule {
 }
 
 public struct LineRule {
-    let token : String
-    let removeFrom : Remove
-    let type : LineStyling
-    let shouldTrim : Bool
-    let changeAppliesTo : ChangeApplication
+    public let token : String
+    public let removeFrom : Remove
+    public var type : LineStyling
+    public let shouldTrim : Bool
+    public let changeAppliesTo : ChangeApplication
     
     public init(token : String, type : LineStyling, removeFrom : Remove = .leading, shouldTrim : Bool = true, changeAppliesTo : ChangeApplication = .current ) {
         self.token = token

--- a/Sources/SwiftyMarkdown/SwiftyMarkdown.swift
+++ b/Sources/SwiftyMarkdown/SwiftyMarkdown.swift
@@ -36,8 +36,8 @@ public enum CharacterStyle : CharacterStyling {
 	}
 }
 
-enum MarkdownLineStyle : LineStyling {
-    var shouldTokeniseLine: Bool {
+public enum MarkdownLineStyle : LineStyling {
+    public var shouldTokeniseLine: Bool {
         switch self {
         case .codeblock:
             return false
@@ -66,7 +66,7 @@ enum MarkdownLineStyle : LineStyling {
 	case orderedListIndentSecondOrder
 	case referencedLink
 	
-    func styleIfFoundStyleAffectsPreviousLine() -> LineStyling? {
+    public func styleIfFoundStyleAffectsPreviousLine() -> LineStyling? {
         switch self {
         case .previousH1:
             return MarkdownLineStyle.h1


### PR DESCRIPTION
Right now it's not possible to easily implement the subset of markdown that would strip all unsupported markdown tags away. The simplest way to do that seem to allow mutating the styles in characters and lines rules. This way users of the library can create set of rules that will strip away unsupported tags, i.e. like this:

```
extension SwiftyMarkdown {
   static private let stripLineRules = SwiftyMarkdown.lineRules.map { rule -> LineRule in 
       var noStyle = rule
       noStyle.type = .body
       return noStyle
   }
   
   static private let stripCharacterRules = SwiftyMarkdown.characterRules.map { rule -> CharacterRule in
        var noStyle = rule
        noStyle.styles = rule.styles.mapValues { _ in
            CharacterStyle.none
        }
        return noStyle
    }
}
```