### PR TITLE
Fix an issue with system font names

### DIFF
--- a/Sources/SwiftyMarkdown/SwiftyMarkdown+iOS.swift
+++ b/Sources/SwiftyMarkdown/SwiftyMarkdown+iOS.swift
@@ -121,10 +121,18 @@ extension SwiftyMarkdown {
 
 			if existentFontName.hasPrefix(".SFUI") {
 				let fontMetrics = UIFontMetrics(forTextStyle: textStyle)
-				font = fontMetrics.scaledFont(for: UIFont.systemFont(ofSize: finalSize))
+                if ignoresDynamicSize {
+                    font = UIFont.systemFont(ofSize: finalSize)
+                } else {
+                    font = fontMetrics.scaledFont(for: UIFont.systemFont(ofSize: finalSize))
+                }
 			} else if let customFont = UIFont(name: existentFontName, size: finalSize)  {
 				let fontMetrics = UIFontMetrics(forTextStyle: textStyle)
-				font = fontMetrics.scaledFont(for: customFont)
+                if ignoresDynamicSize {
+                    font = customFont
+                } else {
+                    font = fontMetrics.scaledFont(for: customFont)
+                }
 			} else {
 				font = UIFont.preferredFont(forTextStyle: textStyle)
 			}

--- a/Sources/SwiftyMarkdown/SwiftyMarkdown+iOS.swift
+++ b/Sources/SwiftyMarkdown/SwiftyMarkdown+iOS.swift
@@ -118,8 +118,11 @@ extension SwiftyMarkdown {
 				let styleDescriptor = UIFontDescriptor.preferredFontDescriptor(withTextStyle: textStyle)
 				finalSize = styleDescriptor.fontAttributes[.size] as? CGFloat ?? CGFloat(14)
 			}
-			
-			if let customFont = UIFont(name: existentFontName, size: finalSize)  {
+
+			if existentFontName.hasPrefix(".SFUI") {
+				let fontMetrics = UIFontMetrics(forTextStyle: textStyle)
+				font = fontMetrics.scaledFont(for: UIFont.systemFont(ofSize: finalSize))
+			} else if let customFont = UIFont(name: existentFontName, size: finalSize)  {
 				let fontMetrics = UIFontMetrics(forTextStyle: textStyle)
 				font = fontMetrics.scaledFont(for: customFont)
 			} else {

--- a/Sources/SwiftyMarkdown/SwiftyMarkdown.swift
+++ b/Sources/SwiftyMarkdown/SwiftyMarkdown.swift
@@ -267,6 +267,8 @@ If that is not set, then the system default will be used.
 	var previouslyFoundTokens : [Token] = []
 	
 	var applyAttachments = true
+    public var ignoresDynamicSize = false
+
 	
 	let perfomanceLog = PerformanceLog(with: "SwiftyMarkdownPerformanceLogging", identifier: "Swifty Markdown", log: .swiftyMarkdownPerformance)
 		


### PR DESCRIPTION
(Solves #92)

Checks if the font name is the system font name, in which case we use the `UIFont.systemFont(ofSize:)` API to generate the font instance.

Using `UIFont(name:size:)` with `.SFUI` fonts currently uses Times New Roman as the default font.