### PR TITLE
Fix crash with invalid URL

### DIFF
--- a/Sources/SwiftyMarkdown/SwiftyMarkdown.swift
+++ b/Sources/SwiftyMarkdown/SwiftyMarkdown.swift
@@ -572,7 +572,7 @@ extension SwiftyMarkdown {
             if let linkIdx = styles.firstIndex(of: .link), linkIdx < token.metadataStrings.count {
                 attributes[.foregroundColor] = self.link.color
                 attributes[.font] = self.font(for: line, characterOverride: .link)
-                attributes[.link] = token.metadataStrings[linkIdx] as AnyObject
+                attributes[.link] = URL(string: token.metadataStrings[linkIdx]) as AnyObject
                 
                 if underlineLinks {
                     attributes[.underlineStyle] = self.link.underlineStyle.rawValue as AnyObject


### PR DESCRIPTION
I have a crash when adding and the attribute is an invalid link. This crash can be caught right in the example project if you change the link in the example.md file `[Links](http://voyagetravelapps.com/)` -> `[Links](http://voyagetravelapps.com/ )` (with spacing). 
The same crash occurs with the text view when the delegate method is called `func textView(_ textView: UITextView, shouldInteractWith URL: URL, in characterRange: NSRange, interaction: UITextItemInteraction) -> Bool`

My example
![image](https://user-images.githubusercontent.com/18508232/102313469-c5651800-3f81-11eb-8c0e-a3d4f998aece.png)
