### PR TITLE
Fix bold font size get's overridden by font descriptor

### DIFF
--- a/Sources/SwiftyMarkdown/SwiftyMarkdown+iOS.swift
+++ b/Sources/SwiftyMarkdown/SwiftyMarkdown+iOS.swift
@@ -130,10 +130,10 @@ extension SwiftyMarkdown {
 		}
 		
 		if globalItalic, let italicDescriptor = font.fontDescriptor.withSymbolicTraits(.traitItalic) {
-			font = UIFont(descriptor: italicDescriptor, size: 0)
+			font = UIFont(descriptor: italicDescriptor, size: fontSize ?? 0)
 		}
 		if globalBold, let boldDescriptor = font.fontDescriptor.withSymbolicTraits(.traitBold) {
-			font = UIFont(descriptor: boldDescriptor, size: 0)
+			font = UIFont(descriptor: boldDescriptor, size: fontSize ?? 0)
 		}
 		
 		return font


### PR DESCRIPTION
(Solves #109)

If a user defined a `fontSize` it will be prefered over the size of the `fontDescriptor` for the bold/italic trait.