### PR TITLE
Apply alignment to images

### DIFF
--- a/Sources/SwiftyMarkdown/SwiftyMarkdown.swift
+++ b/Sources/SwiftyMarkdown/SwiftyMarkdown.swift
@@ -601,18 +601,7 @@ extension SwiftyMarkdown {
                 let str = NSMutableAttributedString(attachment: image1Attachment)
                 str.addAttributes([.paragraphStyle: paragraphStyle], range: NSMakeRange(0, str.length))
                 
-				finalAttributedString.append(str)
-				#elseif !os(watchOS)
-				let image1Attachment = NSTextAttachment()
-				image1Attachment.image = NSImage(named: token.metadataStrings[imgIdx])
-                
-                let paragraphStyle: NSMutableParagraphStyle = NSMutableParagraphStyle()
-                paragraphStyle.alignment = paragraphStyle.alignment = lineProperties.alignment
-
-                let str = NSMutableAttributedString(attachment: image1Attachment)
-                str.addAttributes([.paragraphStyle: paragraphStyle], range: NSMakeRange(0, str.length))
-                
-				finalAttributedString.append(str)
+                finalAttributedString.append(str)
 				#endif
 				continue
 			}


### PR DESCRIPTION
This change takes the text alignment from the current line and applies it to images. My use case is to center an image in the document, which I can now do by applying a e.g. h1 to it and setting h1 to be center aligned.

I also removed a code block that will (to the best of my understanding) never get run, as it's guarded by a `#elseif !os(watchOS)` inside an `#if !os(watchOS)`.