### PR TITLE
Fixed bold + italic annotation

### DIFF
--- a/Sources/SwiftyMarkdown/SwiftyMarkdown+iOS.swift
+++ b/Sources/SwiftyMarkdown/SwiftyMarkdown+iOS.swift
@@ -14,6 +14,10 @@ import UIKit
 extension SwiftyMarkdown {
 	
 	func font( for line : SwiftyLine, characterOverride : CharacterStyle? = nil ) -> UIFont {
+		font(for: line, characterOverrides: characterOverride == nil ? [] : [characterOverride!])
+	}
+	
+	func font( for line : SwiftyLine, characterOverrides : [CharacterStyle]) -> UIFont {
 		let textStyle : UIFont.TextStyle
 		var fontName : String?
 		var fontSize : CGFloat?
@@ -83,7 +87,7 @@ extension SwiftyMarkdown {
 			fontName = body.fontName
 		}
 		
-		if let characterOverride = characterOverride {
+		for characterOverride in characterOverrides {
 			switch characterOverride {
 			case .code:
 				fontName = code.fontName ?? fontName
@@ -129,11 +133,12 @@ extension SwiftyMarkdown {
 			font = UIFont.preferredFont(forTextStyle: textStyle)
 		}
 		
-		if globalItalic, let italicDescriptor = font.fontDescriptor.withSymbolicTraits(.traitItalic) {
-			font = UIFont(descriptor: italicDescriptor, size: fontSize ?? 0)
-		}
-		if globalBold, let boldDescriptor = font.fontDescriptor.withSymbolicTraits(.traitBold) {
+		if globalItalic, globalBold, let boldItalicDescriptor = font.fontDescriptor.withSymbolicTraits([.traitItalic, .traitBold]) {
+			font = UIFont(descriptor: boldItalicDescriptor, size: fontSize ?? 0)
+		} else if globalBold, let boldDescriptor = font.fontDescriptor.withSymbolicTraits(.traitBold) {
 			font = UIFont(descriptor: boldDescriptor, size: fontSize ?? 0)
+		} else if globalItalic, let italicDescriptor = font.fontDescriptor.withSymbolicTraits(.traitItalic) {
+			font = UIFont(descriptor: italicDescriptor, size: fontSize ?? 0)
 		}
 		
 		return font

--- a/Sources/SwiftyMarkdown/SwiftyMarkdown+macOS.swift
+++ b/Sources/SwiftyMarkdown/SwiftyMarkdown+macOS.swift
@@ -11,8 +11,11 @@ import Foundation
 import AppKit
 
 extension SwiftyMarkdown {
-	
 	func font( for line : SwiftyLine, characterOverride : CharacterStyle? = nil ) -> NSFont {
+		font(for: line, characterOverrides: characterOverride == nil ? [] : [characterOverride!])
+	}
+	
+	func font( for line : SwiftyLine, characterOverrides : [CharacterStyle]) -> NSFont {
 		var fontName : String?
 		var fontSize : CGFloat?
 		
@@ -60,7 +63,7 @@ extension SwiftyMarkdown {
 			fontName = body.fontName
 		}
 		
-		if let characterOverride = characterOverride {
+		for characterOverride in characterOverrides {
 			switch characterOverride {
 			case .code:
 				fontName = code.fontName ?? fontName
@@ -99,13 +102,15 @@ extension SwiftyMarkdown {
 			font = NSFont.systemFont(ofSize: finalSize)
 		}
 		
-		if globalItalic {
-			let italicDescriptor = font.fontDescriptor.withSymbolicTraits(.italic)
-			font = NSFont(descriptor: italicDescriptor, size: 0) ?? font
-		}
-		if globalBold {
+		if globalItalic, globalBold {
+			let boldItalicDescriptor = font.fontDescriptor.withSymbolicTraits([.italic, .bold])
+			font = NSFont(descriptor: boldItalicDescriptor, size: 0) ?? font
+		} else if globalBold {
 			let boldDescriptor = font.fontDescriptor.withSymbolicTraits(.bold)
 			font = NSFont(descriptor: boldDescriptor, size: 0) ?? font
+		} else if globalItalic {
+			let italicDescriptor = font.fontDescriptor.withSymbolicTraits(.italic)
+			font = NSFont(descriptor: italicDescriptor, size: 0) ?? font
 		}
 		
 		return font

--- a/Sources/SwiftyMarkdown/SwiftyMarkdown.swift
+++ b/Sources/SwiftyMarkdown/SwiftyMarkdown.swift
@@ -560,13 +560,16 @@ extension SwiftyMarkdown {
 			guard let styles = token.characterStyles as? [CharacterStyle] else {
 				continue
 			}
-			if styles.contains(.italic) {
-				attributes[.font] = self.font(for: line, characterOverride: .italic)
-				attributes[.foregroundColor] = self.italic.color
-			}
-			if styles.contains(.bold) {
+			
+			if styles.contains(.bold) && styles.contains(.italic) {
+				attributes[.font] = self.font(for: line, characterOverrides: [.bold, .italic])
+				attributes[.foregroundColor] = self.bold.color
+			} else if styles.contains(.bold) {
 				attributes[.font] = self.font(for: line, characterOverride: .bold)
 				attributes[.foregroundColor] = self.bold.color
+			} else if styles.contains(.italic) {
+				attributes[.font] = self.font(for: line, characterOverride: .italic)
+				attributes[.foregroundColor] = self.italic.color
 			}
 			
             if let linkIdx = styles.firstIndex(of: .link), linkIdx < token.metadataStrings.count {


### PR DESCRIPTION
It was not possible to create ***"bold italic"*** formatting (`***foo bar***`) even though it is listed as supported in the documentation.

This fixes the issue