### PR TITLE
Added support for iOS 10

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -4,7 +4,7 @@ import PackageDescription
 let package = Package(
     name: "SwiftyMarkdown",
     platforms: [
-        .iOS(SupportedPlatform.IOSVersion.v11),
+        .iOS(SupportedPlatform.IOSVersion.v10),
         .tvOS(SupportedPlatform.TVOSVersion.v11),
 		.macOS(.v10_12),
 		.watchOS(.v4)

--- a/Sources/SwiftyMarkdown/SwiftyMarkdown+iOS.swift
+++ b/Sources/SwiftyMarkdown/SwiftyMarkdown+iOS.swift
@@ -26,25 +26,13 @@ extension SwiftyMarkdown {
 		switch line.lineStyle as! MarkdownLineStyle {
 		case .h1:
 			style = self.h1
-			if #available(iOS 9, *) {
-				textStyle = UIFont.TextStyle.title1
-			} else {
-				textStyle = UIFont.TextStyle.headline
-			}
+            textStyle = UIFont.TextStyle.title1
 		case .h2:
 			style = self.h2
-			if #available(iOS 9, *) {
-				textStyle = UIFont.TextStyle.title2
-			} else {
-				textStyle = UIFont.TextStyle.headline
-			}
+            textStyle = UIFont.TextStyle.title2
 		case .h3:
 			style = self.h3
-			if #available(iOS 9, *) {
-				textStyle = UIFont.TextStyle.title2
-			} else {
-				textStyle = UIFont.TextStyle.subheadline
-			}
+			textStyle = UIFont.TextStyle.title2
 		case .h4:
 			style = self.h4
 			textStyle = UIFont.TextStyle.headline
@@ -120,8 +108,12 @@ extension SwiftyMarkdown {
 			}
 			
 			if let customFont = UIFont(name: existentFontName, size: finalSize)  {
-				let fontMetrics = UIFontMetrics(forTextStyle: textStyle)
-				font = fontMetrics.scaledFont(for: customFont)
+                if #available(iOS 11, *) {
+                    let fontMetrics = UIFontMetrics(forTextStyle: textStyle)
+                    font = fontMetrics.scaledFont(for: customFont)
+                } else {
+                    font = UIFontDescriptor.scaledFont(for: customFont, with: textStyle)
+                }
 			} else {
 				font = UIFont.preferredFont(forTextStyle: textStyle)
 			}

--- a/Sources/SwiftyMarkdown/UIFontDescriptor+SwiftyMarkdown.swift
+++ b/Sources/SwiftyMarkdown/UIFontDescriptor+SwiftyMarkdown.swift
@@ -1,0 +1,164 @@
+//
+//  UIFontDescriptor+SwiftyMarkdown.swift
+//  SwiftyMarkdown
+//
+//  Created by Massimo Oliviero on 17/06/21.
+//
+
+#if !os(macOS)
+
+import UIKit
+
+extension UIFontDescriptor {
+    static let textStyleSizeTable: [UIFont.TextStyle: [UIContentSizeCategory: CGFloat]] = [
+        .title1: [
+            .accessibilityExtraExtraExtraLarge: 58,
+            .accessibilityExtraExtraLarge: 53,
+            .accessibilityExtraLarge: 48,
+            .accessibilityLarge: 43,
+            .accessibilityMedium: 38,
+            .extraExtraExtraLarge: 34,
+            .extraExtraLarge: 32,
+            .extraLarge: 30,
+            .large: 28,
+            .medium: 27,
+            .small: 26,
+            .extraSmall: 25
+        ],
+        .title2: [
+            .accessibilityExtraExtraExtraLarge: 56,
+            .accessibilityExtraExtraLarge: 50,
+            .accessibilityExtraLarge: 44,
+            .accessibilityLarge: 39,
+            .accessibilityMedium: 34,
+            .extraExtraExtraLarge: 28,
+            .extraExtraLarge: 26,
+            .extraLarge: 24,
+            .large: 22,
+            .medium: 21,
+            .small: 20,
+            .extraSmall: 19
+        ],
+        .title3: [
+            .accessibilityExtraExtraExtraLarge: 55,
+            .accessibilityExtraExtraLarge: 49,
+            .accessibilityExtraLarge: 43,
+            .accessibilityLarge: 37,
+            .accessibilityMedium: 31,
+            .extraExtraExtraLarge: 26,
+            .extraExtraLarge: 24,
+            .extraLarge: 22,
+            .large: 20,
+            .medium: 19,
+            .small: 18,
+            .extraSmall: 17
+        ],
+        .callout: [
+            .accessibilityExtraExtraExtraLarge: 51,
+            .accessibilityExtraExtraLarge: 44,
+            .accessibilityExtraLarge: 38,
+            .accessibilityLarge: 32,
+            .accessibilityMedium: 26,
+            .extraExtraExtraLarge: 22,
+            .extraExtraLarge: 20,
+            .extraLarge: 18,
+            .large: 16,
+            .medium: 15,
+            .small: 14,
+            .extraSmall: 13
+        ],
+        .headline: [
+            .accessibilityExtraExtraExtraLarge: 53,
+            .accessibilityExtraExtraLarge: 47,
+            .accessibilityExtraLarge: 40,
+            .accessibilityLarge: 33,
+            .accessibilityMedium: 28,
+            .extraExtraExtraLarge: 23,
+            .extraExtraLarge: 21,
+            .extraLarge: 19,
+            .large: 17,
+            .medium: 16,
+            .small: 15,
+            .extraSmall: 14
+        ],
+        .subheadline: [
+            .accessibilityExtraExtraExtraLarge: 49,
+            .accessibilityExtraExtraLarge: 42,
+            .accessibilityExtraLarge: 36,
+            .accessibilityLarge: 30,
+            .accessibilityMedium: 25,
+            .extraExtraExtraLarge: 21,
+            .extraExtraLarge: 19,
+            .extraLarge: 17,
+            .large: 15,
+            .medium: 14,
+            .small: 13,
+            .extraSmall: 12
+        ],
+        .body: [
+            .accessibilityExtraExtraExtraLarge: 53,
+            .accessibilityExtraExtraLarge: 47,
+            .accessibilityExtraLarge: 40,
+            .accessibilityLarge: 33,
+            .accessibilityMedium: 28,
+            .extraExtraExtraLarge: 23,
+            .extraExtraLarge: 21,
+            .extraLarge: 19,
+            .large: 17,
+            .medium: 16,
+            .small: 15,
+            .extraSmall: 14
+        ],
+        .caption1: [
+            .accessibilityExtraExtraExtraLarge: 43,
+            .accessibilityExtraExtraLarge: 37,
+            .accessibilityExtraLarge: 32,
+            .accessibilityLarge: 26,
+            .accessibilityMedium: 22,
+            .extraExtraExtraLarge: 18,
+            .extraExtraLarge: 16,
+            .extraLarge: 14,
+            .large: 12,
+            .medium: 11,
+            .small: 11,
+            .extraSmall: 11
+        ],
+        .caption2: [
+            .accessibilityExtraExtraExtraLarge: 40,
+            .accessibilityExtraExtraLarge: 34,
+            .accessibilityExtraLarge: 29,
+            .accessibilityLarge: 24,
+            .accessibilityMedium: 20,
+            .extraExtraExtraLarge: 17,
+            .extraExtraLarge: 15,
+            .extraLarge: 13,
+            .large: 11,
+            .medium: 11,
+            .small: 11,
+            .extraSmall: 11
+        ],
+        .footnote: [
+            .accessibilityExtraExtraExtraLarge: 44,
+            .accessibilityExtraExtraLarge: 38,
+            .accessibilityExtraLarge: 33,
+            .accessibilityLarge: 27,
+            .accessibilityMedium: 23,
+            .extraExtraExtraLarge: 19,
+            .extraExtraLarge: 17,
+            .extraLarge: 15,
+            .large: 13,
+            .medium: 12,
+            .small: 12,
+            .extraSmall: 12
+        ]
+    ]
+
+    static func scaledFont(for font: UIFont, with textStyle: UIFont.TextStyle) -> UIFont {
+        let contentSize = UIApplication.shared.preferredContentSizeCategory
+        let fontSize = textStyleSizeTable[textStyle]?[contentSize] ?? UIFont.systemFontSize
+        let descriptor = UIFontDescriptor(name: font.fontName, size: fontSize)
+        return UIFont(descriptor: descriptor, size: 0)
+    }
+}
+
+#endif

--- a/SwiftyMarkdown.podspec
+++ b/SwiftyMarkdown.podspec
@@ -8,7 +8,7 @@ s.author           = { "Simon Fairbairn" => "simon@voyagetravelapps.com" }
 s.source           = { :git => "https://github.com/SimonFairbairn/SwiftyMarkdown.git", :tag => s.version }
 s.social_media_url = 'https://twitter.com/SimonFairbairn'
 
-s.ios.deployment_target = "11.0"
+s.ios.deployment_target = "10.0"
 s.tvos.deployment_target = "11.0"
 s.osx.deployment_target = "10.12"
 s.watchos.deployment_target = "4.0"

--- a/SwiftyMarkdown.xcodeproj/project.pbxproj
+++ b/SwiftyMarkdown.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 /* End PBXAggregateTarget section */
 
 /* Begin PBXBuildFile section */
+		56A32CD4267B910C00A3EFED /* UIFontDescriptor+SwiftyMarkdown.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56A32CD3267B910C00A3EFED /* UIFontDescriptor+SwiftyMarkdown.swift */; };
 		F4ACB6CB23E8A5C500EA665D /* SwiftyScanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4ACB6CA23E8A5C500EA665D /* SwiftyScanner.swift */; };
 		F4ACB6CE23E8A88400EA665D /* Token.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4ACB6CD23E8A88400EA665D /* Token.swift */; };
 		F4ACB6D023E8A8A500EA665D /* CharacterRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4ACB6CF23E8A8A500EA665D /* CharacterRule.swift */; };
@@ -59,6 +60,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		56A32CD3267B910C00A3EFED /* UIFontDescriptor+SwiftyMarkdown.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIFontDescriptor+SwiftyMarkdown.swift"; sourceTree = "<group>"; };
 		F4ACB6CA23E8A5C500EA665D /* SwiftyScanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftyScanner.swift; sourceTree = "<group>"; };
 		F4ACB6CD23E8A88400EA665D /* Token.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Token.swift; sourceTree = "<group>"; };
 		F4ACB6CF23E8A8A500EA665D /* CharacterRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CharacterRule.swift; sourceTree = "<group>"; };
@@ -169,16 +171,17 @@
 		OBJ_8 /* SwiftyMarkdown */ = {
 			isa = PBXGroup;
 			children = (
-				OBJ_9 /* String+SwiftyMarkdown.swift */,
-				OBJ_10 /* SwiftyLineProcessor.swift */,
-				OBJ_11 /* SwiftyMarkdown+iOS.swift */,
-				OBJ_12 /* SwiftyMarkdown+macOS.swift */,
-				OBJ_13 /* SwiftyMarkdown.swift */,
-				OBJ_14 /* SwiftyTokeniser.swift */,
-				F4ACB6CD23E8A88400EA665D /* Token.swift */,
-				F4ACB6CA23E8A5C500EA665D /* SwiftyScanner.swift */,
 				F4ACB6CF23E8A8A500EA665D /* CharacterRule.swift */,
 				F4ACB6D123E8B08400EA665D /* PerfomanceLog.swift */,
+				OBJ_9 /* String+SwiftyMarkdown.swift */,
+				OBJ_10 /* SwiftyLineProcessor.swift */,
+				OBJ_13 /* SwiftyMarkdown.swift */,
+				OBJ_11 /* SwiftyMarkdown+iOS.swift */,
+				OBJ_12 /* SwiftyMarkdown+macOS.swift */,
+				F4ACB6CA23E8A5C500EA665D /* SwiftyScanner.swift */,
+				OBJ_14 /* SwiftyTokeniser.swift */,
+				F4ACB6CD23E8A88400EA665D /* Token.swift */,
+				56A32CD3267B910C00A3EFED /* UIFontDescriptor+SwiftyMarkdown.swift */,
 			);
 			name = SwiftyMarkdown;
 			path = Sources/SwiftyMarkdown;
@@ -268,6 +271,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 0;
 			files = (
+				56A32CD4267B910C00A3EFED /* UIFontDescriptor+SwiftyMarkdown.swift in Sources */,
 				OBJ_40 /* String+SwiftyMarkdown.swift in Sources */,
 				OBJ_41 /* SwiftyLineProcessor.swift in Sources */,
 				F4ACB6D223E8B08400EA665D /* PerfomanceLog.swift in Sources */,


### PR DESCRIPTION
Currently, the minimum deployment target is iOS 11. But, the only issue in using the library on iOS 10 is the `UIFontMetric` class that is not available in iOS 10.

This PR introduces an extension to the `UIFontDescriptor` class, used only on iOS 10, that mimics the behavior of the UIFontMetric class on iOS 10.