### PR TITLE
Fixing issue #82 - Expose MarkdownLineStyle as public

### DIFF
--- a/Sources/SwiftyMarkdown/SwiftyMarkdown.swift
+++ b/Sources/SwiftyMarkdown/SwiftyMarkdown.swift
@@ -36,8 +36,8 @@ public enum CharacterStyle : CharacterStyling {
 	}
 }
 
-enum MarkdownLineStyle : LineStyling {
-    var shouldTokeniseLine: Bool {
+public enum MarkdownLineStyle : LineStyling {
+    public var shouldTokeniseLine: Bool {
         switch self {
         case .codeblock:
             return false
@@ -66,7 +66,7 @@ enum MarkdownLineStyle : LineStyling {
 	case orderedListIndentSecondOrder
 	case referencedLink
 	
-    func styleIfFoundStyleAffectsPreviousLine() -> LineStyling? {
+    public func styleIfFoundStyleAffectsPreviousLine() -> LineStyling? {
         switch self {
         case .previousH1:
             return MarkdownLineStyle.h1


### PR DESCRIPTION
Fixing issue #82 - Now `MarkdownLineStyle` (and also `shouldTokeniseLine` and `styleIfFoundStyleAffectsPreviousLine()` are now declared public