### PR TITLE
Use correct blockquotes style when setting font sizes

### DIFF
--- a/Playground/SwiftyMarkdown.playground/Sources/SwiftyMarkdown.swift
+++ b/Playground/SwiftyMarkdown.playground/Sources/SwiftyMarkdown.swift
@@ -216,7 +216,7 @@ If that is not set, then the system default will be used.
 		bold.fontSize = size
 		code.fontSize = size
 		link.fontSize = size
-		link.fontSize = size
+		blockquotes.fontSize = size
 	}
 	
 	open func setFontColorForAllStyles(with color: UIColor) {


### PR DESCRIPTION
Seems like `link.fontSize = size` was copied twice by mistake there.