### PR TITLE
Add support for scaling images and containing image

### DIFF
--- a/Sources/SwiftyMarkdown/SwiftyMarkdown.swift
+++ b/Sources/SwiftyMarkdown/SwiftyMarkdown.swift
@@ -622,7 +622,7 @@ extension SwiftyMarkdown {
 				let str = NSAttributedString(attachment: image1Attachment)
 				finalAttributedString.append(str)
 				#elseif !os(watchOS)
-				let image1Attachment = ImageAttachment(imageScale: imageScale, containImage: containImageWidth)
+				let image1Attachment = ImageAttachment(imageScale: imageScale, containImageWidth: containImageWidth)
 				image1Attachment.image = NSImage(named: token.metadataStrings[imgIdx])
 				let str = NSAttributedString(attachment: image1Attachment)
 				finalAttributedString.append(str)


### PR DESCRIPTION
This PR adds the following features.
- Scale images by a specified ratio
- Shrink images to contain them when the width is larger than the display area

ex.
```swift
md.imageScale = 0.5
md.containImageWidth = true
```