### PR TITLE
Fixing issue #129

### DIFF
--- a/Sources/SwiftyMarkdown/SwiftyScanner.swift
+++ b/Sources/SwiftyMarkdown/SwiftyScanner.swift
@@ -419,7 +419,8 @@ class SwiftyScanner {
 					os_log("Multiple open metadata tags found!", log: OSLog.swiftyScanner, type:.info , groupID)
 				}
 				self.resetTag(in: range)
-				self.resetTagGroup(withID: groupID)
+                // should not reset tag group. such as [123(asd)]()
+//				self.resetTagGroup(withID: groupID)
 				self.isMetadataOpen = false
 				continue
 			}

--- a/Sources/SwiftyMarkdown/SwiftyScanner.swift
+++ b/Sources/SwiftyMarkdown/SwiftyScanner.swift
@@ -419,7 +419,7 @@ class SwiftyScanner {
 					os_log("Multiple open metadata tags found!", log: OSLog.swiftyScanner, type:.info , groupID)
 				}
 				self.resetTag(in: range)
-                // should not reset tag group. such as [123(asd)]()
+                // should not reset tag group. such as [123(asd)](), just same as normal body characters
 //				self.resetTagGroup(withID: groupID)
 				self.isMetadataOpen = false
 				continue


### PR DESCRIPTION
Fixing issue https://github.com/SimonFairbairn/SwiftyMarkdown/issues/129

there's a bug about the close tag.

the origin markdown below:
` [Links(asd)](http://voyagetravelapps.com/).`
and result image below:
<img width="307" alt="image" src="https://user-images.githubusercontent.com/6223098/172368984-9ca73d87-f5ed-4dcf-bb3a-32c6021c1e2d.png">