### PR TITLE
New `ignoreDynamicFontSize` property for iOS

### DIFF
--- a/Sources/SwiftyMarkdown/SwiftyMarkdown+iOS.swift
+++ b/Sources/SwiftyMarkdown/SwiftyMarkdown+iOS.swift
@@ -128,6 +128,10 @@ extension SwiftyMarkdown {
 		} else {
 			font = UIFont.preferredFont(forTextStyle: textStyle)
 		}
+        
+        if ignoreDynamicFontSize, let fontSize = fontSize {
+            font = font.withSize(fontSize)
+        }
 		
 		if globalItalic, let italicDescriptor = font.fontDescriptor.withSymbolicTraits(.traitItalic) {
 			font = UIFont(descriptor: italicDescriptor, size: fontSize ?? 0)

--- a/Sources/SwiftyMarkdown/SwiftyMarkdown+iOS.swift
+++ b/Sources/SwiftyMarkdown/SwiftyMarkdown+iOS.swift
@@ -128,10 +128,10 @@ extension SwiftyMarkdown {
 		} else {
 			font = UIFont.preferredFont(forTextStyle: textStyle)
 		}
-        
-        if ignoreDynamicFontSize, let fontSize = fontSize {
-            font = font.withSize(fontSize)
-        }
+		
+		if ignoreDynamicFontSize, let fontSize = fontSize {
+			font = font.withSize(fontSize)
+		}
 		
 		if globalItalic, let italicDescriptor = font.fontDescriptor.withSymbolicTraits(.traitItalic) {
 			font = UIFont(descriptor: italicDescriptor, size: fontSize ?? 0)

--- a/Sources/SwiftyMarkdown/SwiftyMarkdown.swift
+++ b/Sources/SwiftyMarkdown/SwiftyMarkdown.swift
@@ -249,6 +249,9 @@ If that is not set, then the system default will be used.
 	public var bullet : String = "・"
 	
 	public var underlineLinks : Bool = false
+    
+    /// **iOS only** : Setting this boolean to true will force using the exact size set for each style.
+    public var ignoreDynamicFontSize : Bool = false
 	
 	public var frontMatterAttributes : [String : String] {
 		get {

--- a/Sources/SwiftyMarkdown/SwiftyMarkdown.swift
+++ b/Sources/SwiftyMarkdown/SwiftyMarkdown.swift
@@ -250,7 +250,7 @@ If that is not set, then the system default will be used.
 	
 	public var underlineLinks : Bool = false
     
-    /// **iOS only** : Setting this boolean to true will force using the exact size set for each style.
+    /// **iOS only** : Setting this boolean to true will force using the exact size set for each style if available.
     public var ignoreDynamicFontSize : Bool = false
 	
 	public var frontMatterAttributes : [String : String] {

--- a/Sources/SwiftyMarkdown/SwiftyMarkdown.swift
+++ b/Sources/SwiftyMarkdown/SwiftyMarkdown.swift
@@ -249,9 +249,9 @@ If that is not set, then the system default will be used.
 	public var bullet : String = "・"
 	
 	public var underlineLinks : Bool = false
-    
-    /// **iOS only** : Setting this boolean to true will force using the exact size set for each style if available.
-    public var ignoreDynamicFontSize : Bool = false
+	
+	/// **iOS only** : Setting this boolean to true will force using the exact size set for each style if available.
+	public var ignoreDynamicFontSize : Bool = false
 	
 	public var frontMatterAttributes : [String : String] {
 		get {


### PR DESCRIPTION
This PR adds a new `ignoreDynamicFontSize` property that is necessary if you want to set sizes for other styles then `italic` or `bold` without setting the fontName (you cannot get SFUI font via name).

Inspired by an old but [still opened PR](https://github.com/SimonFairbairn/SwiftyMarkdown/pull/100).