### PR TITLE
Fix complex pattern hanging forever

### DIFF
--- a/Sources/SwiftyMarkdown/SwiftyScanner.swift
+++ b/Sources/SwiftyMarkdown/SwiftyScanner.swift
@@ -259,7 +259,8 @@ class SwiftyScanner {
 		} else {
 			var remainingTags = min(openRange.upperBound - openRange.lowerBound, closeRange.upperBound - closeRange.lowerBound) + 1
 			while remainingTags > 0 {
-				if remainingTags >= self.rule.maxTags {
+				let shouldAppendStyle = remainingTags >= self.rule.maxTags
+				if shouldAppendStyle {
 					remainingTags -= self.rule.maxTags
 					if let style = self.rule.styles[ self.rule.maxTags ] {
 						if !styles.contains(where: { $0.isEqualTo(style)}) {
@@ -267,11 +268,17 @@ class SwiftyScanner {
 						}
 					}
 				}
-				if let style = self.rule.styles[remainingTags] {
+
+				let remainingTagsStyle = self.rule.styles[remainingTags]
+				if let style = remainingTagsStyle {
 					remainingTags -= remainingTags
 					if !styles.contains(where: { $0.isEqualTo(style)}) {
 						styles.append(style)
 					}
+				}
+
+				if !shouldAppendStyle && remainingTagsStyle == nil {
+					break
 				}
 			}
 			

--- a/Tests/SwiftyMarkdownTests/SwiftyMarkdownAttributedStringTests.swift
+++ b/Tests/SwiftyMarkdownTests/SwiftyMarkdownAttributedStringTests.swift
@@ -30,8 +30,15 @@ A more *complicated* example. This one has **it all**. Here is a [link](http://v
 		XCTAssertNotNil(attributedString)
 		
 		XCTAssertEqual(attributedString.string, "Heading 1\n\nA more complicated example. This one has it all. Here is a link.\n\nHeading 2\n\nHeading 3\n\nThis one is a blockquote")
-		
-		
 	}
-	
+
+    func testComplexPatternDoesNotHangForever() {
+        let string = "**~*~~~*~*~**~*~* h e a r d ***~*~*~**~*~~~*"
+
+        let md = SwiftyMarkdown(string: string)
+        let attributedString = md.attributedString()
+
+        XCTAssertNotNil(attributedString)
+        XCTAssertEqual(attributedString.string, "**~~*~**~~ h e a r d ***~~~**~")
+    }
 }


### PR DESCRIPTION
This PR fixes an issue where a complex pattern would hang forever, and never return, leaving an app in a complete freeze.
The string is `**~*~~~*~*~**~*~* h e a r d ***~*~*~**~*~~~* `

The library would detect the initial `~~~` pattern as the start of a tag, and the one at the end as the end of it. But the `closeTag` method would never return as `remainingTags` would never reach 0.
